### PR TITLE
Add support for KSCrash

### DIFF
--- a/NSExceptionKtKSCrash/KSCrashNSExceptionKtReporter.swift
+++ b/NSExceptionKtKSCrash/KSCrashNSExceptionKtReporter.swift
@@ -1,0 +1,24 @@
+import NSExceptionKtCoreObjC
+import KSCrash
+
+public extension NSExceptionKtReporter where Self == NSExceptionKtReporter {
+    /// Configures KSCrash and creates a ``NSExceptionKtCoreObjC/NSExceptionKtReporter`` that will report unhandled Kotlin exceptions to KSCrash.
+    /// - Returns: A ``NSExceptionKtCoreObjC/NSExceptionKtReporter`` that will report exceptions to KSCrash.
+    static func kscrash() -> NSExceptionKtReporter {
+        return KSCrashNSExceptionKtReporter.shared
+    }
+}
+
+private class KSCrashNSExceptionKtReporter: NSExceptionKtReporter {
+    
+    static let shared = KSCrashNSExceptionKtReporter()
+    
+    private init() {}
+    
+    var requiresMergedException: Bool = false
+    
+    func reportException(_ exceptions: [NSException]) {
+        guard let exception = exceptions.first else { return }
+        KSCrash.sharedInstance().reportUserException(exception.name, reason: exception.reason, callStackReturnAddresses: exception.callStackReturnAddresses, causes: exceptions.dropFirst().map { $0 })
+    }
+}

--- a/NSExceptionKtKSCrash/README.md
+++ b/NSExceptionKtKSCrash/README.md
@@ -1,0 +1,89 @@
+# NSExceptionKt for KSCrash
+
+## Introduction
+
+The `NSExceptionKtKSCrash` module provides integration with KSCrash for reporting unhandled Kotlin exceptions. This module allows you to log unhandled exceptions to KSCrash, ensuring that you have detailed crash reports for your Kotlin applications on Apple platforms.
+
+## Installation
+
+First, make sure you have set up KSCrash in your project. You can add KSCrash to your project using Swift Package Manager by adding the following dependency to your `Package.swift` file:
+
+```swift
+.package(url: "https://github.com/kstenerud/KSCrash.git", from: "1.15.24")
+```
+
+After that, add and export the Kotlin dependency to your `appleMain` source set.
+
+```kotlin
+kotlin {
+    iosArm64 { // and/or any other Apple target 
+        binaries.framework {
+            isStatic = true // it's recommended to use a static framework
+            export("com.rickclephas.kmp:nsexception-kt-core:<version>")
+        }
+    }
+    sourceSets {
+        appleMain {
+            dependencies {
+                api("com.rickclephas.kmp:nsexception-kt-core:<version>")
+            }
+        }
+    }
+}
+```
+
+## Usage
+
+To configure and use the `NSExceptionKtKSCrash` module to report unhandled Kotlin exceptions to KSCrash, follow these steps:
+
+1. Import the necessary modules in your Swift code:
+
+```swift
+import KSCrash
+import NSExceptionKtKSCrash
+import shared // This is your shared Kotlin module
+```
+
+2. Update your application delegate to configure KSCrash and add the reporter:
+
+```swift
+class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
+    ) -> Bool {
+        let kscrash = KSCrash.sharedInstance()
+        NSExceptionKt.addReporter(.kscrash())
+        return true
+    }
+}
+```
+
+## Example
+
+Here is a complete example demonstrating the configuration and usage of the `NSExceptionKtKSCrash` module:
+
+```swift
+import UIKit
+import KSCrash
+import NSExceptionKtKSCrash
+import shared // This is your shared Kotlin module
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
+    ) -> Bool {
+        let kscrash = KSCrash.sharedInstance()
+        NSExceptionKt.addReporter(.kscrash())
+        return true
+    }
+}
+```
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](../LICENSE.txt) file for more details.

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,10 @@ let package = Package(
         .library(
             name: "NSExceptionKtBugsnag",
             targets: ["NSExceptionKtBugsnag"]
+        ),
+        .library(
+            name: "NSExceptionKtKSCrash",
+            targets: ["NSExceptionKtKSCrash"]
         )
     ],
     dependencies: [
@@ -24,6 +28,10 @@ let package = Package(
         .package(
             url: "https://github.com/bugsnag/bugsnag-cocoa.git",
             "6.22.1"..<"7.0.0"
+        ),
+        .package(
+            url: "https://github.com/kstenerud/KSCrash.git",
+            "1.15.24"..<"2.0.0"
         )
     ],
     targets: [
@@ -55,6 +63,15 @@ let package = Package(
                 .product(name: "Bugsnag", package: "bugsnag-cocoa")
             ],
             path: "NSExceptionKtBugsnag"
+        ),
+        
+        .target(
+            name: "NSExceptionKtKSCrash",
+            dependencies: [
+                .target(name: "NSExceptionKtCoreObjC"),
+                .product(name: "KSCrash", package: "KSCrash")
+            ],
+            path: "NSExceptionKtKSCrash"
         )
     ],
     swiftLanguageVersions: [.v5]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Checkout the implementation specific `README`s for usage and installation detail
 
 * [Crashlytics](NSExceptionKtCrashlytics/README.md)
 * [Bugsnag](NSExceptionKtBugsnag/README.md)
+* [KSCrash](NSExceptionKtKSCrash/README.md)
 
 ## Why this library?
 

--- a/nsexception-kt-kscrash/build.gradle.kts
+++ b/nsexception-kt-kscrash/build.gradle.kts
@@ -46,6 +46,7 @@ kotlin {
         it.compilations.getByName("main") {
             cinterops.create("KSCrash") {
                 includeDirs("$projectDir/src/nativeInterop/cinterop/KSCrash")
+                definitionFile("$projectDir/src/nativeInterop/cinterop/KSCrash.def")
             }
         }
     }

--- a/nsexception-kt-kscrash/build.gradle.kts
+++ b/nsexception-kt-kscrash/build.gradle.kts
@@ -1,0 +1,52 @@
+plugins {
+    @Suppress("DSL_SCOPE_VIOLATION")
+    alias(libs.plugins.kotlin.multiplatform)
+    `nsexception-kt-publish`
+}
+
+kotlin {
+    explicitApi()
+    jvmToolchain(11)
+
+    val macosX64 = macosX64()
+    val macosArm64 = macosArm64()
+    val iosArm64 = iosArm64()
+    val iosX64 = iosX64()
+    val iosSimulatorArm64 = iosSimulatorArm64()
+    val watchosArm32 = watchosArm32()
+    val watchosArm64 = watchosArm64()
+    val watchosX64 = watchosX64()
+    val watchosSimulatorArm64 = watchosSimulatorArm64()
+    val watchosDeviceArm64 = watchosDeviceArm64()
+    val tvosArm64 = tvosArm64()
+    val tvosX64 = tvosX64()
+    val tvosSimulatorArm64 = tvosSimulatorArm64()
+
+    sourceSets {
+        all {
+            languageSettings.optIn("com.rickclephas.kmp.nsexceptionkt.core.InternalNSExceptionKtApi")
+        }
+        commonMain {
+            dependencies {
+                implementation(project(":nsexception-kt-core"))
+            }
+        }
+        commonTest {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
+    }
+    listOf(
+        macosX64, macosArm64,
+        iosArm64, iosX64, iosSimulatorArm64,
+        watchosArm32, watchosArm64, watchosX64, watchosSimulatorArm64, watchosDeviceArm64,
+        tvosArm64, tvosX64, tvosSimulatorArm64
+    ).forEach {
+        it.compilations.getByName("main") {
+            cinterops.create("KSCrash") {
+                includeDirs("$projectDir/src/nativeInterop/cinterop/KSCrash")
+            }
+        }
+    }
+}

--- a/nsexception-kt-kscrash/src/commonMain/kotlin/com/rickclephas/kmp/nsexceptionkt/kscrash/KSCrash.kt
+++ b/nsexception-kt-kscrash/src/commonMain/kotlin/com/rickclephas/kmp/nsexceptionkt/kscrash/KSCrash.kt
@@ -1,0 +1,34 @@
+package com.rickclephas.kmp.nsexceptionkt.kscrash
+
+import com.rickclephas.kmp.nsexceptionkt.kscrash.cinterop.*
+import com.rickclephas.kmp.nsexceptionkt.core.asNSException
+import com.rickclephas.kmp.nsexceptionkt.core.causes
+import com.rickclephas.kmp.nsexceptionkt.core.wrapUnhandledExceptionHook
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSException
+
+/**
+ * Sets the unhandled exception hook such that all unhandled exceptions are logged to KSCrash as fatal exceptions.
+ * If an unhandled exception hook was already set, that hook will be invoked after the exception is logged.
+ * Note: once the exception is logged the program will be terminated.
+ * @see wrapUnhandledExceptionHook
+ */
+@OptIn(ExperimentalForeignApi::class)
+public fun setKSCrashUnhandledExceptionHook(): Unit = wrapUnhandledExceptionHook { throwable ->
+    val exception = throwable.asNSException()
+    val causes = throwable.causes.map { it.asNSException() }
+    // Notify will persist unhandled events, so we can safely terminate afterwards.
+    // https://github.com/kstenerud/KSCrash/blob/master/Source/KSCrash/Recording/Tools/KSLogger.c#L744
+    KSCrash.sharedInstance().reportUserException(exception.name, exception.reason, exception.callStackReturnAddresses, causes)
+}
+
+/**
+ * Converts `this` [NSException] to a [KSCrashReport].
+ */
+@OptIn(ExperimentalForeignApi::class)
+private fun NSException.asKSCrashReport(): KSCrashReport = KSCrashReport().apply {
+    errorClass = name
+    errorMessage = reason
+    stacktrace = KSCrashStackframe.stackframesWithCallStackReturnAddresses(callStackReturnAddresses)
+    type = KSCrashErrorType.KSCrashErrorTypeCocoa
+}

--- a/nsexception-kt-kscrash/src/commonTest/kotlin/com/rickclephas/kmp/nsexceptionkt/kscrash/KSCrashTests.kt
+++ b/nsexception-kt-kscrash/src/commonTest/kotlin/com/rickclephas/kmp/nsexceptionkt/kscrash/KSCrashTests.kt
@@ -1,0 +1,40 @@
+package com.rickclephas.kmp.nsexceptionkt.kscrash
+
+import com.rickclephas.kmp.nsexceptionkt.core.asNSException
+import com.rickclephas.kmp.nsexceptionkt.core.causes
+import com.rickclephas.kmp.nsexceptionkt.core.wrapUnhandledExceptionHook
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class KSCrashTests {
+
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun testSetKSCrashUnhandledExceptionHook() {
+        var hookCalled = false
+        wrapUnhandledExceptionHook { throwable ->
+            hookCalled = true
+            val exception = throwable.asNSException()
+            val causes = throwable.causes.map { it.asNSException() }
+            assertNotNull(exception)
+            assertTrue(causes.isNotEmpty())
+        }
+        setKSCrashUnhandledExceptionHook()
+        throw RuntimeException("Test exception")
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun testAsKSCrashReport() {
+        val exception = NSException("TestException", "Test reason", null)
+        val report = exception.asKSCrashReport()
+        assertEquals("TestException", report.errorClass)
+        assertEquals("Test reason", report.errorMessage)
+        assertNotNull(report.stacktrace)
+        assertEquals(KSCrashErrorType.KSCrashErrorTypeCocoa, report.type)
+    }
+}

--- a/nsexception-kt-kscrash/src/nativeInterop/cinterop/KSCrash.def
+++ b/nsexception-kt-kscrash/src/nativeInterop/cinterop/KSCrash.def
@@ -1,0 +1,3 @@
+language = Objective-C
+package = com.rickclephas.kmp.nsexceptionkt.kscrash.cinterop
+headers = KSCrash.h

--- a/nsexception-kt-kscrash/src/nativeInterop/cinterop/KSCrash/KSCrash.h
+++ b/nsexception-kt-kscrash/src/nativeInterop/cinterop/KSCrash/KSCrash.h
@@ -1,0 +1,32 @@
+#import <Foundation/Foundation.h>
+
+@interface KSCrash : NSObject
+
++ (instancetype _Nonnull)sharedInstance;
+- (void)reportUserException:(NSString *_Nonnull)name
+                     reason:(NSString *_Nullable)reason
+          callStackReturnAddresses:(NSArray<NSNumber *> *_Nonnull)callStackReturnAddresses
+                     causes:(NSArray<NSException *> *_Nonnull)causes;
+
+@end
+
+@interface KSCrashReport : NSObject
+
+@property (copy, nullable, nonatomic) NSString *errorClass;
+@property (copy, nullable, nonatomic) NSString *errorMessage;
+@property (copy, nonnull, nonatomic) NSArray *stacktrace;
+@property (nonatomic) NSUInteger type;
+
+@end
+
+typedef NS_ENUM(NSUInteger, KSCrashErrorType) {
+    KSCrashErrorTypeCocoa,
+    KSCrashErrorTypeC,
+    KSCrashErrorTypeReactNativeJs
+};
+
+@interface KSCrashStackframe : NSObject
+
++ (NSArray<KSCrashStackframe *> *_Nonnull)stackframesWithCallStackReturnAddresses:(NSArray<NSNumber *> *_Nonnull)callStackReturnAddresses;
+
+@end


### PR DESCRIPTION
Add support for KSCrash integration.

* **Package.swift**
  - Add KSCrash as a dependency.
  - Add `NSExceptionKtKSCrash` target.
* **README.md**
  - Add instructions for integrating KSCrash.
* **nsexception-kt-kscrash/build.gradle.kts**
  - Add Kotlin Multiplatform plugin.
  - Add `nsexception-kt-publish` plugin.
  - Configure Kotlin targets.
  - Add dependencies for `nsexception-kt-core`.
  - Add cinterop for KSCrash.
* **nsexception-kt-kscrash/src/commonMain/kotlin/com/rickclephas/kmp/nsexceptionkt/kscrash/KSCrash.kt**
  - Implement KSCrash integration.
  - Add function to set unhandled exception hook.
  - Add function to convert `NSException` to `KSCrashReport`.

