### PR TITLE
Complete KSCrash implementation

### DIFF
--- a/NSExceptionKtKSCrash/KSCrashNSExceptionKtReporter.swift
+++ b/NSExceptionKtKSCrash/KSCrashNSExceptionKtReporter.swift
@@ -1,0 +1,24 @@
+import NSExceptionKtCoreObjC
+import KSCrash
+
+public extension NSExceptionKtReporter where Self == NSExceptionKtReporter {
+    /// Configures KSCrash and creates a ``NSExceptionKtCoreObjC/NSExceptionKtReporter`` that will report unhandled Kotlin exceptions to KSCrash.
+    /// - Returns: A ``NSExceptionKtCoreObjC/NSExceptionKtReporter`` that will report exceptions to KSCrash.
+    static func kscrash() -> NSExceptionKtReporter {
+        return KSCrashNSExceptionKtReporter.shared
+    }
+}
+
+private class KSCrashNSExceptionKtReporter: NSExceptionKtReporter {
+    
+    static let shared = KSCrashNSExceptionKtReporter()
+    
+    private init() {}
+    
+    var requiresMergedException: Bool = false
+    
+    func reportException(_ exceptions: [NSException]) {
+        guard let exception = exceptions.first else { return }
+        KSCrash.sharedInstance().reportUserException(exception.name, reason: exception.reason, callStackReturnAddresses: exception.callStackReturnAddresses, causes: exceptions.dropFirst().map { $0 })
+    }
+}

--- a/NSExceptionKtKSCrash/README.md
+++ b/NSExceptionKtKSCrash/README.md
@@ -1,0 +1,89 @@
+# NSExceptionKt for KSCrash
+
+## Introduction
+
+The `NSExceptionKtKSCrash` module provides integration with KSCrash for reporting unhandled Kotlin exceptions. This module allows you to log unhandled exceptions to KSCrash, ensuring that you have detailed crash reports for your Kotlin applications on Apple platforms.
+
+## Installation
+
+First, make sure you have set up KSCrash in your project. You can add KSCrash to your project using Swift Package Manager by adding the following dependency to your `Package.swift` file:
+
+```swift
+.package(url: "https://github.com/kstenerud/KSCrash.git", from: "1.15.24")
+```
+
+After that, add and export the Kotlin dependency to your `appleMain` source set.
+
+```kotlin
+kotlin {
+    iosArm64 { // and/or any other Apple target 
+        binaries.framework {
+            isStatic = true // it's recommended to use a static framework
+            export("com.rickclephas.kmp:nsexception-kt-core:<version>")
+        }
+    }
+    sourceSets {
+        appleMain {
+            dependencies {
+                api("com.rickclephas.kmp:nsexception-kt-core:<version>")
+            }
+        }
+    }
+}
+```
+
+## Usage
+
+To configure and use the `NSExceptionKtKSCrash` module to report unhandled Kotlin exceptions to KSCrash, follow these steps:
+
+1. Import the necessary modules in your Swift code:
+
+```swift
+import KSCrash
+import NSExceptionKtKSCrash
+import shared // This is your shared Kotlin module
+```
+
+2. Update your application delegate to configure KSCrash and add the reporter:
+
+```swift
+class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
+    ) -> Bool {
+        let kscrash = KSCrash.sharedInstance()
+        NSExceptionKt.addReporter(.kscrash())
+        return true
+    }
+}
+```
+
+## Example
+
+Here is a complete example demonstrating the configuration and usage of the `NSExceptionKtKSCrash` module:
+
+```swift
+import UIKit
+import KSCrash
+import NSExceptionKtKSCrash
+import shared // This is your shared Kotlin module
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
+    ) -> Bool {
+        let kscrash = KSCrash.sharedInstance()
+        NSExceptionKt.addReporter(.kscrash())
+        return true
+    }
+}
+```
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](../LICENSE.txt) file for more details.

--- a/nsexception-kt-kscrash/src/nativeInterop/cinterop/KSCrash/KSCrash.h
+++ b/nsexception-kt-kscrash/src/nativeInterop/cinterop/KSCrash/KSCrash.h
@@ -1,0 +1,32 @@
+#import <Foundation/Foundation.h>
+
+@interface KSCrash : NSObject
+
++ (instancetype _Nonnull)sharedInstance;
+- (void)reportUserException:(NSString *_Nonnull)name
+                     reason:(NSString *_Nullable)reason
+          callStackReturnAddresses:(NSArray<NSNumber *> *_Nonnull)callStackReturnAddresses
+                     causes:(NSArray<NSException *> *_Nonnull)causes;
+
+@end
+
+@interface KSCrashReport : NSObject
+
+@property (copy, nullable, nonatomic) NSString *errorClass;
+@property (copy, nullable, nonatomic) NSString *errorMessage;
+@property (copy, nonnull, nonatomic) NSArray *stacktrace;
+@property (nonatomic) NSUInteger type;
+
+@end
+
+typedef NS_ENUM(NSUInteger, KSCrashErrorType) {
+    KSCrashErrorTypeCocoa,
+    KSCrashErrorTypeC,
+    KSCrashErrorTypeReactNativeJs
+};
+
+@interface KSCrashStackframe : NSObject
+
++ (NSArray<KSCrashStackframe *> *_Nonnull)stackframesWithCallStackReturnAddresses:(NSArray<NSNumber *> *_Nonnull)callStackReturnAddresses;
+
+@end


### PR DESCRIPTION
Add KSCrash integration for reporting unhandled Kotlin exceptions.

* **KSCrashNSExceptionKtReporter.swift**
  - Define `KSCrashNSExceptionKtReporter` class conforming to `NSExceptionKtReporter` protocol.
  - Implement `requiresMergedException` property and `reportException` method.
  - Add static method in `NSExceptionKtReporter` extension to configure KSCrash and return an instance of `KSCrashNSExceptionKtReporter`.

* **README.md**
  - Create a README file with sections: Introduction, Installation, Usage, Example, License.

* **KSCrash.h**
  - Add KSCrash header file with necessary class and method definitions.

