### PR TITLE
Fix KSCrash Cinterop task by adding definitionFile parameter

### DIFF
--- a/nsexception-kt-kscrash/build.gradle.kts
+++ b/nsexception-kt-kscrash/build.gradle.kts
@@ -46,6 +46,7 @@ kotlin {
         it.compilations.getByName("main") {
             cinterops.create("KSCrash") {
                 includeDirs("$projectDir/src/nativeInterop/cinterop/KSCrash")
+                definitionFile("$projectDir/src/nativeInterop/cinterop/KSCrash.def")
             }
         }
     }

--- a/nsexception-kt-kscrash/src/nativeInterop/cinterop/KSCrash.def
+++ b/nsexception-kt-kscrash/src/nativeInterop/cinterop/KSCrash.def
@@ -1,0 +1,3 @@
+language = Objective-C
+package = com.rickclephas.kmp.nsexceptionkt.kscrash.cinterop
+headers = KSCrash.h


### PR DESCRIPTION
Add `definitionFile` parameter to the Cinterop task for `KSCrash`.

* Modify `nsexception-kt-kscrash/build.gradle.kts` to include the `definitionFile` parameter in the Cinterop task for `KSCrash`.
* Add `nsexception-kt-kscrash/src/nativeInterop/cinterop/KSCrash.def` file with the following content:
  - Set `language` to `Objective-C`
  - Set `package` to `com.rickclephas.kmp.nsexceptionkt.kscrash.cinterop`
  - Set `headers` to `KSCrash.h`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/santhoshkumar-sn-7134/NSExceptionKt/pull/3?shareId=dd06c977-05a1-4fb3-ac96-d997f6b79741).