### PR TITLE
Add tests for KSCrash integration

### DIFF
--- a/nsexception-kt-kscrash/src/commonTest/kotlin/com/rickclephas/kmp/nsexceptionkt/kscrash/KSCrashTests.kt
+++ b/nsexception-kt-kscrash/src/commonTest/kotlin/com/rickclephas/kmp/nsexceptionkt/kscrash/KSCrashTests.kt
@@ -1,0 +1,40 @@
+package com.rickclephas.kmp.nsexceptionkt.kscrash
+
+import com.rickclephas.kmp.nsexceptionkt.core.asNSException
+import com.rickclephas.kmp.nsexceptionkt.core.causes
+import com.rickclephas.kmp.nsexceptionkt.core.wrapUnhandledExceptionHook
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class KSCrashTests {
+
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun testSetKSCrashUnhandledExceptionHook() {
+        var hookCalled = false
+        wrapUnhandledExceptionHook { throwable ->
+            hookCalled = true
+            val exception = throwable.asNSException()
+            val causes = throwable.causes.map { it.asNSException() }
+            assertNotNull(exception)
+            assertTrue(causes.isNotEmpty())
+        }
+        setKSCrashUnhandledExceptionHook()
+        throw RuntimeException("Test exception")
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun testAsKSCrashReport() {
+        val exception = NSException("TestException", "Test reason", null)
+        val report = exception.asKSCrashReport()
+        assertEquals("TestException", report.errorClass)
+        assertEquals("Test reason", report.errorMessage)
+        assertNotNull(report.stacktrace)
+        assertEquals(KSCrashErrorType.KSCrashErrorTypeCocoa, report.type)
+    }
+}


### PR DESCRIPTION
Add tests for KSCrash integration.

* **Add KSCrashTests class**
  - Add `KSCrashTests` class in `nsexception-kt-kscrash/src/commonTest/kotlin/com/rickclephas/kmp/nsexceptionkt/kscrash/KSCrashTests.kt`
  - Import necessary dependencies for testing

* **Add testSetKSCrashUnhandledExceptionHook function**
  - Add `testSetKSCrashUnhandledExceptionHook` function to test `setKSCrashUnhandledExceptionHook`
  - Verify unhandled exceptions are logged to KSCrash as fatal exceptions

* **Add testAsKSCrashReport function**
  - Add `testAsKSCrashReport` function to test `asKSCrashReport`
  - Verify conversion of `NSException` to `KSCrashReport`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/santhoshkumar-sn-7134/NSExceptionKt/pull/4?shareId=b7c97551-5e88-4330-a73e-6cebc161045d).